### PR TITLE
Fix props UI prompt radio input

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ page = props.PropsUIPageDonation(platform, header, body, footer)
 ```
 </details>
 
+<summary>Create page with radio buttons</summary>
+
+```Python   
+header = props.PropsUIHeader(title)
+footer = props.PropsUIFooter(progress)
+body = props.PropsUIPromptRadioInput(title, description, [{"id": 0, "value": "Selection 1"}, {"id": 1, "value": "Selection 2"}])
+page = props.PropsUIPageDonation(platform, header, body, footer)
+```
+
+</details>
+
 <details>
 <summary>Handling file input result</summary>
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ page = props.PropsUIPageDonation(platform, header, body, footer)
 ```
 </details>
 
+<details>
 <summary>Create page with radio buttons</summary>
 
 ```Python   

--- a/src/framework/types/pages.ts
+++ b/src/framework/types/pages.ts
@@ -1,6 +1,6 @@
 import { isInstanceOf } from '../helpers'
 import { PropsUIFooter, PropsUIHeader } from './elements'
-import { PropsUIPromptFileInput, PropsUIPromptConfirm, PropsUIPromptConsentForm } from './prompts'
+import { PropsUIPromptFileInput, PropsUIPromptConfirm, PropsUIPromptConsentForm, PropsUIPromptRadioInput } from './prompts'
 
 export type PropsUIPage =
   PropsUIPageSplashScreen |
@@ -26,7 +26,7 @@ export interface PropsUIPageDonation {
   __type__: 'PropsUIPageDonation'
   platform: string
   header: PropsUIHeader
-  body: PropsUIPromptFileInput | PropsUIPromptConfirm | PropsUIPromptConsentForm
+  body: PropsUIPromptFileInput | PropsUIPromptConfirm | PropsUIPromptConsentForm | PropsUIPromptRadioInput
   footer: PropsUIFooter
 }
 export function isPropsUIPageDonation (arg: any): arg is PropsUIPageDonation {

--- a/src/framework/visualisation/react/ui/pages/donation_page.tsx
+++ b/src/framework/visualisation/react/ui/pages/donation_page.tsx
@@ -4,13 +4,14 @@ import TextBundle from '../../../../text_bundle'
 import { Translator } from '../../../../translator'
 import { Translatable } from '../../../../types/elements'
 import { PropsUIPageDonation } from '../../../../types/pages'
-import { isPropsUIPromptConfirm, isPropsUIPromptConsentForm, isPropsUIPromptFileInput } from '../../../../types/prompts'
+import { isPropsUIPromptConfirm, isPropsUIPromptConsentForm, isPropsUIPromptFileInput, isPropsUIPromptRadioInput } from '../../../../types/prompts'
 import { ReactFactoryContext } from '../../factory'
 import { ForwardButton } from '../elements/button'
 import { Title1 } from '../elements/text'
 import { Confirm } from '../prompts/confirm'
 import { ConsentForm } from '../prompts/consent_form'
 import { FileInput } from '../prompts/file_input'
+import { RadioInput } from '../prompts/radio_input'
 import { Footer } from './templates/footer'
 import { Sidebar } from './templates/sidebar'
 import LogoSvg from '../../../../../assets/images/logo.svg'
@@ -35,6 +36,9 @@ export const DonationPage = (props: Props): JSX.Element => {
     }
     if (isPropsUIPromptConsentForm(body)) {
       return <ConsentForm {...body} {...context} />
+    }
+    if (isPropsUIPromptRadioInput(body)) {
+      return <RadioInput {...body} {...context} />
     }
     throw new TypeError('Unknown body type')
   }


### PR DESCRIPTION
As you can see in the diffs, only imports were missing. 
Works as expected now.

If you feel the need to test:

```python
def test_radio_button(progress):
    title = props.Translatable({
        "en": f"title",
        "nl": f"title"
    })
    description = props.Translatable({
        "en": f"description",
        "nl": f"description"
    })
    header = props.PropsUIHeader(props.Translatable({
        "en": "header",
        "nl": "header"
    }))

    body = props.PropsUIPromptRadioInput(title, description, [{"id": 0, "value": "Selection 1"}, {"id": 1, "value": "Selection 2"}])
    footer = props.PropsUIFooter(progress)
    page = props.PropsUIPageDonation("Twitter", header, body, footer)
    return CommandUIRender(page)

```

Stick this one below the definition of `progress` in `proces()` in `script.py`:

```python
yield test_radio_button(progress)
```