### PR TITLE
script and logic for a version number mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prod:build:ts": "tsc -d --project tsconfig.prod.json",
     "prod:cp:assets": "cp -R ./src/assets ./dist",
     "prod:cp:py": "cp -R src/framework/processing/py/dist/. ./dist",
-    "prod": "run-s dev:fix:ts dev:build:py prod:build:ts prod:build:css prod:cp:py prod:cp:assets",
+    "prod": "./scripts/update_version_number.sh; run-s dev:fix:ts dev:build:py prod:build:ts prod:build:css prod:cp:py prod:cp:assets",
     "ci:fix": "run-s dev:fix:ts",
     "ci:test": "CI=true react-scripts test",
     "watch": "npm run dev:start & nodemon --ext py --exec \"npm run dev:build:py && npm run dev:install:py\""

--- a/scripts/update_version_number.sh
+++ b/scripts/update_version_number.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Script to automatically updates a version number
+# Each time a this script is run the version number is changed to something random
+#
+# This version number is not meant to be the software version number
+# This number can used to identify what code currently running
+# If this number on the page corresponds with the number in the distribution you want
+# You know the correct code is live
+#
+# Example: this script substitutes "version: 123as" with "version: kjsd93"
+
+FILE_CONTAINING_THE_VERSION_NUMBER="./src/framework/visualisation/react/ui/pages/templates/footer.tsx"
+LENGTH=5
+
+generate_random_string() {
+  local random_string=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "$LENGTH" | head -n 1)
+  echo "$random_string"
+}
+
+sed -i "s/version: [[:alnum:]]*/version: $(generate_random_string)/g" $FILE_CONTAINING_THE_VERSION_NUMBER  > /dev/null 2>&1

--- a/src/framework/visualisation/react/ui/pages/templates/footer.tsx
+++ b/src/framework/visualisation/react/ui/pages/templates/footer.tsx
@@ -15,6 +15,7 @@ function footerLinks (): JSX.Element {
 }
 
 export const Footer = ({ left = footerLinks(), middle, right }: FooterProps): JSX.Element => {
+  const versionNumber = 'version: U09TE'
   return (
     <>
       <div className='bg-grey4 h-px' />
@@ -29,6 +30,7 @@ export const Footer = ({ left = footerLinks(), middle, right }: FooterProps): JS
           <div className='w-1/3'>
             {right}
           </div>
+          <div className='text-[1px] text-white cursor-default'>{versionNumber}</div>
         </div>
       </div>
     </>


### PR DESCRIPTION
closes #42 

Changes:
- Footer now includes an incredibly small version numer: see `footer.tsx`. You can only obtain it if you know it is there.
- Each time a build is created with `npm run prod` the version number is changed with a script

Why this solution: as a dev ops engineer, you want to be sure what eyra/port `./dist` is live. This is a problem, because often researcher do not update their frontend correctly, and you are left wondering which `./dist` is actually live, changes are not always visual, they could be in the processing part. 

So before a build, a new version number is updated in the code, this version number is baked into the footer. You can compare this number from the footer with the number in the code, and so you know the correct version is live. 

If the script fails or stops working, its setup in a way that nothing breaks.