### PR TITLE
fix copyFileToPyFS

### DIFF
--- a/src/framework/processing/py_worker.js
+++ b/src/framework/processing/py_worker.js
@@ -60,15 +60,16 @@ function unwrap(response) {
 }
 
 function copyFileToPyFS(file, resolve) {
-  self.pyodide.FS.mkdir('/file-input')
+  directoryName = `/file-input${crypto.randomUUID()}`
+  self.pyodide.FS.mkdir(directoryName)
   self.pyodide.FS.mount(
     self.pyodide.FS.filesystems.WORKERFS,
     {
       files: [file]
     },
-    '/file-input'
+    directoryName
   )
-  resolve({ __type__: 'PayloadString', value: '/file-input/' + file.name })
+  resolve({ __type__: 'PayloadString', value: directoryName + '/' + file.name })
 }
 
 function initialise() {


### PR DESCRIPTION
 self.pyodide.FS.mkdir() cannot make the same dir twice, if the code block triggers twice. The code crashes. 
Proposed solution, make dirname unique so it can always be mounted.

`crypto.randomUUID()` is apparently the cannonical way of generating uuid's however it only works in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). I am not quite sure how does work exactly, its good to verify it also works if the webworker is actually served.

A fix has to be applied to stable as well

