### PR TITLE
fix from Kasper, determine rowcount once, prevents sudden slow downs …

### DIFF
--- a/src/framework/visualisation/react/ui/prompts/consent_form.tsx
+++ b/src/framework/visualisation/react/ui/prompts/consent_form.tsx
@@ -80,7 +80,8 @@ export const ConsentForm = (props: Props): JSX.Element => {
 
   function rows (data: any): PropsUITableRow[] {
     const result: PropsUITableRow[] = []
-    for (let row = 0; row <= rowCount(data); row++) {
+    const nRows = rowCount(data)
+    for (let row = 0; row <= nRows; row++) {
       const id = `${row}`
       const cells = columnNames(data).map((column: string) => rowCell(data, column, row))
       result.push({ __type__: 'PropsUITableRow', id, cells })


### PR DESCRIPTION
#### Large tables wont load

Fix from Kasper, it prevents a case where tables wont load at all. The repeated call of rowCount becomes a sudden problem if the row count exceeds a certain number.